### PR TITLE
chore: pin GitHub Actions to commit SHAs

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -8,13 +8,13 @@ jobs:
   build:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v6
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
         name: ⬇️ Checkout repository
-      - uses: oven-sh/setup-bun@v2
+      - uses: oven-sh/setup-bun@0c5077e51419868618aeaa5fe8019c62421857d6 # v2.2.0
         name: 🛠️ Setup bun
         with:
           bun-version: latest
-      - uses: actions/setup-node@v6
+      - uses: actions/setup-node@53b83947a5a98c8d113130e565377fae1a50d02f # v6.3.0
         name: 📦 Setup Node.js
         with:
           node-version: 23

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -21,13 +21,13 @@ jobs:
     runs-on: ubuntu-latest
     timeout-minutes: 10
     steps:
-      - uses: actions/checkout@v6
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
         name: ⬇️ Checkout repository
-      - uses: oven-sh/setup-bun@v2
+      - uses: oven-sh/setup-bun@0c5077e51419868618aeaa5fe8019c62421857d6 # v2.2.0
         name: 🛠️ Setup bun
         with:
           bun-version: latest
-      - uses: actions/setup-node@v6
+      - uses: actions/setup-node@53b83947a5a98c8d113130e565377fae1a50d02f # v6.3.0
         name: 📦 Setup Node.js
         with:
           node-version: 23
@@ -43,7 +43,7 @@ jobs:
           cp README.md packages/messenger-webhooks/
       - name: 🚀 Publish release
         id: changesets
-        uses: changesets/action@v1
+        uses: changesets/action@6a0a831ff30acef54f2c6aa1cbbc1096b066edaf # v1.7.0
         with:
           publish: bun run release
         env:


### PR DESCRIPTION
## Summary

- Pin `actions/checkout`, `oven-sh/setup-bun`, `actions/setup-node`, and `changesets/action` to full commit SHAs in both `ci.yml` and `publish.yml`
- Prevents supply chain attacks from mutable version tags

## Test plan

- [x] CI passes on this PR

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated CI/CD workflow action versions to latest patches for improved stability and security.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->